### PR TITLE
Implement resourceExists()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 .settings/
 .vscode/
 target/
-idea/
+.idea/
 *.iml

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>maven-wagon-gs</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Maven Wagon that can resolve and retrieve artifacts from Google Storage</description>
-    <version>0.1</version>
+    <version>0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>http://www.github.com/synack/maven-wagon-gs</url>
 

--- a/src/main/java/com/synack/maven/wagon/gs/GSWagon.java
+++ b/src/main/java/com/synack/maven/wagon/gs/GSWagon.java
@@ -22,9 +22,13 @@ public class GSWagon extends StreamWagon {
     private static Logger log = LoggerFactory.getLogger(GSWagon.class);
     private Storage storage;
 
+    private String getBucketName() {
+        return getRepository().getHost();
+    }
+
     @Override
-    public void fillInputData(InputData inputData) throws TransferFailedException, ResourceDoesNotExistException, AuthorizationException {
-        String bucketName = getRepository().getHost();
+    public void fillInputData(InputData inputData) throws ResourceDoesNotExistException {
+        String bucketName = getBucketName();
         String resourceName = inputData.getResource().getName();
         log.info("Downloading: gs://" + bucketName + "/" + resourceName);
 
@@ -42,12 +46,17 @@ public class GSWagon extends StreamWagon {
         inputData.getResource().setLastModified(blob.getUpdateTime());
     }
 
+    @Override
+    public boolean resourceExists(String resourceName) {
+        return storage.get(getBucketName()).get(resourceName) != null;
+    }
+
     /**
      * Upload a file to gs
      */
     @Override
-    public void fillOutputData(OutputData outputData) throws TransferFailedException {
-        String bucketName = getRepository().getHost();
+    public void fillOutputData(OutputData outputData) {
+        String bucketName = getBucketName();
         String resourceName = outputData.getResource().getName();
         log.info("Uploading: gs://" + bucketName + "/" + resourceName);
 
@@ -57,7 +66,7 @@ public class GSWagon extends StreamWagon {
     }
 
     @Override
-    protected void openConnectionInternal() throws ConnectionException, AuthenticationException {
+    protected void openConnectionInternal() throws ConnectionException {
         if (!"/".equals(getRepository().getBasedir())) {
             throw new ConnectionException("Not supported: Url contains path");
         }
@@ -65,6 +74,6 @@ public class GSWagon extends StreamWagon {
     }
 
     @Override
-    public void closeConnection() throws ConnectionException {
+    public void closeConnection() {
     }
 }

--- a/src/main/java/com/synack/maven/wagon/gs/GSWagon.java
+++ b/src/main/java/com/synack/maven/wagon/gs/GSWagon.java
@@ -5,8 +5,6 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import org.apache.maven.wagon.*;
-import org.apache.maven.wagon.authentication.AuthenticationException;
-import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,8 +45,14 @@ public class GSWagon extends StreamWagon {
     }
 
     @Override
-    public boolean resourceExists(String resourceName) {
-        return storage.get(getBucketName()).get(resourceName) != null;
+    public boolean resourceExists(final String resourceName) throws TransferFailedException {
+        final Bucket bucket = storage.get(getBucketName());
+
+        if (bucket == null) {
+            throw new TransferFailedException(String.format("Cannot find bucket '%s'", getBucketName()));
+        } else {
+            return storage.get(resourceName) != null;
+        }
     }
 
     /**


### PR DESCRIPTION
When the wagon is used in different projects with ids for the same bucket in the repository configuration, for example:

```xml
<repository>
    <id>repo1</id>
    <url>gs://my-bucket</url>
</repository>
```

```xml
<repository>
    <id>repo2</id>
    <url>gs://my-bucket</url>
</repository>
```

Maven will throw an error saying, that the wagon needs to implement `resourceExists()` in order to cope with the different repository ids.

This PR introduces the implementation for that method and some minor refactorings. Moreover, the Wagon version has been increased to 0.2-SNAPSHOT. It would be nice to have a release of version 0.2 very soon.