### PR TITLE
Search for blob, not bucket in resourceExists()

### DIFF
--- a/src/main/java/com/synack/maven/wagon/gs/GSWagon.java
+++ b/src/main/java/com/synack/maven/wagon/gs/GSWagon.java
@@ -51,7 +51,7 @@ public class GSWagon extends StreamWagon {
         if (bucket == null) {
             throw new TransferFailedException(String.format("Cannot find bucket '%s'", getBucketName()));
         } else {
-            return storage.get(resourceName) != null;
+            return bucket.get(resourceName) != null;
         }
     }
 


### PR DESCRIPTION
There is a dumb error in the implementation of `resourceExists()`, where the resource is searched for as a bucket, not a blob in a bucket.